### PR TITLE
fix: fix mount overlayfs lower error

### DIFF
--- a/src/mount/overlay.rs
+++ b/src/mount/overlay.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result, bail};
 use log::{info, warn};
 use std::{
     ffi::CString,
-    os::fd::AsRawFd,
     path::{Path, PathBuf},
     thread,
 };


### PR DESCRIPTION
we don't open stock_root, and fixed the calling method

This should now be consistent with the behavior of meta-overlayfs.