### PR TITLE
Revert "fix: use extattr to test overlay"

### DIFF
--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -158,7 +158,7 @@ pub fn setup(
 
 fn try_setup_tmpfs(target: &Path, mount_source: &str) -> Result<bool> {
     if utils::mount_tmpfs(target, mount_source).is_ok() {
-        if utils::is_overlay_xattr_supported(target).is_ok() {
+        if utils::is_overlay_xattr_supported(target) {
             return Ok(true);
         } else {
             let _ = unmount(target, UnmountFlags::DETACH);


### PR DESCRIPTION
This reverts commit 5e597d673f4880262d0401555749d0690415744e.