### PR TITLE
Make CI fork-friendly: skip Telegram notify if secrets missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           cargo xtask build --release --arch arm64
 
       - name: Notify Telegram (CI)
-        if: success() && github.event_name != 'pull_request'
+        if: ${{ success() && github.event_name != 'pull_request' && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != '' }}
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
Hi again :)

As I noticed before, the CI (`build.yml`) fails on forks because they don't have access to the Telegram secrets.
I added a check to skip the notification step if those secrets aren't found. Now the build will pass for everyone.

Below I've added a screenshot showing a successfully sent notification when secrets are available:

<details>
  <summary>📷 Screenshot: Telegram Notification</summary>

![Screenshot_2026-01-17-16-05-01-38_948cd9899890cbd5c2798760b2b95377](https://github.com/user-attachments/assets/9f6487f7-8762-49e9-a412-4df01dcea9ef)

</details>
