### PR TITLE
🦉 Jules: Secure atomic_write with /dev/urandom

### DIFF
--- a/.jules/journal.md
+++ b/.jules/journal.md
@@ -1,0 +1,3 @@
+## 2026-01-23 - Secure Temporary Files
+**洞察:** `SystemTime` based naming and `File::create` are insufficient for secure temporary file creation in shared environments.
+**准则:** Use `/dev/urandom` for naming and `OpenOptions::new().create_new(true)` for atomic creation.


### PR DESCRIPTION
🧹 **What:** Refactored `atomic_write` in `src/utils.rs` to use `/dev/urandom` for temporary filename generation and `OpenOptions` for atomic file creation. Added a unit test to verify functionality.
🛡️ **Why:** The previous implementation used `SystemTime` for random naming and `File::create` which is not atomic (truncates if exists). This violated the "Backend Security Standard" and posed a potential risk of file clobbering or predictability in shared environments.
🔍 **Review Guide:** Check `src/utils.rs`. A new helper `read_urandom` was added. `atomic_write` now ensures `create_new(true)`. A `tests` module was added at the end of the file.

---
*PR created automatically by Jules for task [12313190230907940117](https://jules.google.com/task/12313190230907940117) started by @YuzakiKokuban*