### PR TITLE
Add snapshot-based sync checks, safer path handling, and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "hybrid-mount"
-version = "3.1.2"
+version = "3.1.5"
 dependencies = [
  "android_logger",
  "anyhow",

--- a/src/core/ops/planner.rs
+++ b/src/core/ops/planner.rs
@@ -243,10 +243,14 @@ pub fn generate(
                             .unwrap_or_else(|_| resolved_target.clone())
                     } else if let Some(parent) = resolved_target.parent() {
                         if parent.exists() {
-                            parent
-                                .canonicalize()
-                                .map(|p| p.join(resolved_target.file_name().unwrap()))
-                                .unwrap_or_else(|_| resolved_target.clone())
+                            if let Some(file_name) = resolved_target.file_name() {
+                                parent
+                                    .canonicalize()
+                                    .map(|p| p.join(file_name))
+                                    .unwrap_or_else(|_| resolved_target.clone())
+                            } else {
+                                resolved_target.clone()
+                            }
                         } else {
                             resolved_target.clone()
                         }

--- a/src/core/ops/sync.rs
+++ b/src/core/ops/sync.rs
@@ -137,17 +137,68 @@ fn should_sync(src: &Path, dst: &Path) -> bool {
     }
 
     let src_prop = src.join("module.prop");
-
     let dst_prop = dst.join("module.prop");
 
     if !src_prop.exists() || !dst_prop.exists() {
         return true;
     }
 
-    match (fs::read(&src_prop), fs::read(&dst_prop)) {
-        (Ok(s), Ok(d)) => s != d,
+    if !matches!((fs::read(&src_prop), fs::read(&dst_prop)), (Ok(s), Ok(d)) if s == d) {
+        return true;
+    }
+
+    match (collect_snapshot(src), collect_snapshot(dst)) {
+        (Ok(src_snapshot), Ok(dst_snapshot)) => src_snapshot != dst_snapshot,
         _ => true,
     }
+}
+
+fn collect_snapshot(root: &Path) -> Result<Vec<String>> {
+    let mut snapshot = Vec::new();
+
+    for entry in WalkDir::new(root).into_iter().flatten() {
+        let path = entry.path();
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+
+        let file_type = entry.file_type();
+        if file_type.is_dir() {
+            snapshot.push(format!("d:{}", relative));
+            continue;
+        }
+
+        if file_type.is_symlink() {
+            let target = fs::read_link(path)
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default();
+            snapshot.push(format!("l:{}:{}", relative, target));
+            continue;
+        }
+
+        let metadata = fs::symlink_metadata(path)?;
+        let content_hash = fs::read(path)
+            .ok()
+            .map(|data| {
+                use std::hash::{Hash, Hasher};
+                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                data.hash(&mut hasher);
+                hasher.finish()
+            })
+            .unwrap_or_default();
+        snapshot.push(format!(
+            "f:{}:{}:{}",
+            relative,
+            metadata.len(),
+            content_hash
+        ));
+    }
+
+    snapshot.sort();
+    Ok(snapshot)
 }
 
 fn has_files_recursive(path: &Path) -> bool {
@@ -160,4 +211,82 @@ fn has_files_recursive(path: &Path) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn create_temp_dir(name: &str) -> std::path::PathBuf {
+        let base = std::env::temp_dir();
+        let unique = format!(
+            "hybrid_mount_sync_test_{}_{}_{}",
+            name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let dir = base.join(unique);
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        let mut file = fs::File::create(path).expect("create file");
+        file.write_all(content.as_bytes()).expect("write file");
+    }
+
+    #[test]
+    fn should_sync_when_dst_missing() {
+        let src = create_temp_dir("dst_missing_src");
+        let dst = create_temp_dir("dst_missing_dst");
+        let dst_target = dst.join("not_exists");
+
+        write_file(&src.join("module.prop"), "id=a\n");
+
+        assert!(should_sync(&src, &dst_target));
+
+        let _ = fs::remove_dir_all(src);
+        let _ = fs::remove_dir_all(dst);
+    }
+
+    #[test]
+    fn should_sync_when_payload_changes_with_same_module_prop() {
+        let src = create_temp_dir("payload_src");
+        let dst = create_temp_dir("payload_dst");
+
+        write_file(&src.join("module.prop"), "id=a\nname=A\n");
+        write_file(&dst.join("module.prop"), "id=a\nname=A\n");
+
+        write_file(&src.join("system/bin/app_process"), "v2");
+        write_file(&dst.join("system/bin/app_process"), "v1");
+
+        assert!(should_sync(&src, &dst));
+
+        let _ = fs::remove_dir_all(src);
+        let _ = fs::remove_dir_all(dst);
+    }
+
+    #[test]
+    fn should_not_sync_when_snapshots_equal() {
+        let src = create_temp_dir("equal_src");
+        let dst = create_temp_dir("equal_dst");
+
+        write_file(&src.join("module.prop"), "id=a\nname=A\n");
+        write_file(&dst.join("module.prop"), "id=a\nname=A\n");
+
+        write_file(&src.join("system/etc/test.conf"), "same");
+        write_file(&dst.join("system/etc/test.conf"), "same");
+
+        assert!(!should_sync(&src, &dst));
+
+        let _ = fs::remove_dir_all(src);
+        let _ = fs::remove_dir_all(dst);
+    }
 }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -7,7 +7,10 @@ use std::{
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::{defs, sys::fs::xattr};
+use crate::{
+    defs,
+    sys::fs::{atomic_write, xattr},
+};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct RuntimeState {
@@ -57,7 +60,7 @@ impl RuntimeState {
 
     pub fn save(&self) -> Result<()> {
         let json = serde_json::to_string_pretty(self)?;
-        fs::write(defs::STATE_FILE, json)?;
+        atomic_write(defs::STATE_FILE, format!("{}\n", json))?;
         Ok(())
     }
 

--- a/src/mount/magic_mount/mod.rs
+++ b/src/mount/magic_mount/mod.rs
@@ -102,11 +102,10 @@ impl MagicMount {
             &self.path
         };
 
-        if self.node.module_path.is_none() {
-            bail!("cannot mount root file {}!", self.path.display());
-        }
-
-        let module_path = &self.node.module_path.clone().unwrap();
+        let module_path =
+            self.node.module_path.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("cannot mount root file {}!", self.path.display())
+            })?;
 
         log::debug!(
             "mount module file {} -> {}",

--- a/src/mount/magic_mount/utils.rs
+++ b/src/mount/magic_mount/utils.rs
@@ -121,7 +121,7 @@ pub fn collect_module_files(
             continue;
         }
 
-        let id = entry.file_name().to_str().unwrap().to_string();
+        let id = entry.file_name().to_string_lossy().to_string();
         log::debug!("processing new module: {id}");
 
         if !need_id.contains(&id) {


### PR DESCRIPTION
### Motivation

- Avoid incorrect sync behavior that only compared `module.prop` by adding a payload snapshot comparison to detect content changes. 
- Prevent panics and unwraps when file names or module paths are absent and make file/path handling more robust and portable. 
- Ensure state is written atomically and add unit tests to validate sync decisions. 

### Description

- Implement `collect_snapshot` which walks a module directory with `WalkDir` and builds a normalized snapshot of directories, symlinks, and files (including sizes and a simple content hash) for deterministic comparison. 
- Update `should_sync` to short-circuit when `module.prop` contents differ and otherwise compare snapshots from `collect_snapshot` to decide whether to sync. 
- Add unit tests for `should_sync` covering missing destinations, payload changes with identical `module.prop`, and equal snapshots. 
- Replace several panics/unsafe unwraps with safe handling: check for `file_name()` presence in `planner.rs`, convert `module_path` `Option` into a `Result` in `magic_mount::regular_file`, and use `to_string_lossy()` for module IDs in `collect_module_files`. 
- Use `atomic_write` when saving `RuntimeState` to avoid partial writes. 
- Bump `hybrid-mount` dependency in `Cargo.lock` from `3.1.2` to `3.1.5`.

### Testing

- Ran unit tests with `cargo test`, which included the new `should_sync` tests, and they passed. 
- Basic build verification with `cargo build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6eb0a6c388325b2fc922be8c59da0)