### PR TITLE
Auto-promote prereleases after grace period and publish releases as prerelease

### DIFF
--- a/.github/workflows/promote_prerelease.yml
+++ b/.github/workflows/promote_prerelease.yml
@@ -1,0 +1,173 @@
+name: Promote Release After Grace Period
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  promote-local-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Promote newest eligible prerelease in current repository
+        id: promote
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const gracePeriodMs = 3 * 24 * 60 * 60 * 1000;
+            const now = Date.now();
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const eligible = releases
+              .filter((release) => {
+                if (release.draft || !release.prerelease) {
+                  return false;
+                }
+
+                const publishedAt = release.published_at ?? release.created_at;
+                if (!publishedAt) {
+                  return false;
+                }
+
+                return now - new Date(publishedAt).getTime() >= gracePeriodMs;
+              })
+              .sort((a, b) => {
+                const aTime = new Date(a.published_at ?? a.created_at).getTime();
+                const bTime = new Date(b.published_at ?? b.created_at).getTime();
+                return bTime - aTime;
+              });
+
+            const target = eligible[0];
+            if (!target) {
+              core.info(`No eligible prereleases found for ${owner}/${repo}.`);
+              core.setOutput('promoted', 'false');
+              return;
+            }
+
+            core.info(`Promoting latest eligible prerelease ${target.tag_name} in ${owner}/${repo}.`);
+            await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: target.id,
+              draft: false,
+              prerelease: false,
+            });
+
+            core.setOutput('promoted', 'true');
+            core.setOutput('tag_name', target.tag_name);
+            core.setOutput('html_url', target.html_url);
+            core.setOutput('repo_name', `${owner}/${repo}`);
+
+      - name: Notify Telegram for local promotion
+        if: ${{ steps.promote.outputs.promoted == 'true' && secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RELEASE_TAG: ${{ steps.promote.outputs.tag_name }}
+          RELEASE_URL: ${{ steps.promote.outputs.html_url }}
+          RELEASE_REPO: ${{ steps.promote.outputs.repo_name }}
+        run: |
+          MESSAGE=$(cat <<EOF
+          ✅ Release promoted to stable
+          Repository: ${RELEASE_REPO}
+          Tag: ${RELEASE_TAG}
+          URL: ${RELEASE_URL}
+          EOF
+          )
+
+          curl --fail --silent --show-error \
+            -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}"
+
+  promote-remote-release:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.RELEASE_TOKEN != '' }}
+    steps:
+      - name: Promote newest eligible prerelease in KernelSU-Modules-Repo/hybrid_mount
+        id: promote
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+          script: |
+            const gracePeriodMs = 3 * 24 * 60 * 60 * 1000;
+            const now = Date.now();
+            const owner = 'KernelSU-Modules-Repo';
+            const repo = 'hybrid_mount';
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const eligible = releases
+              .filter((release) => {
+                if (release.draft || !release.prerelease) {
+                  return false;
+                }
+
+                const publishedAt = release.published_at ?? release.created_at;
+                if (!publishedAt) {
+                  return false;
+                }
+
+                return now - new Date(publishedAt).getTime() >= gracePeriodMs;
+              })
+              .sort((a, b) => {
+                const aTime = new Date(a.published_at ?? a.created_at).getTime();
+                const bTime = new Date(b.published_at ?? b.created_at).getTime();
+                return bTime - aTime;
+              });
+
+            const target = eligible[0];
+            if (!target) {
+              core.info(`No eligible prereleases found for ${owner}/${repo}.`);
+              core.setOutput('promoted', 'false');
+              return;
+            }
+
+            core.info(`Promoting latest eligible prerelease ${target.tag_name} in ${owner}/${repo}.`);
+            await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: target.id,
+              draft: false,
+              prerelease: false,
+            });
+
+            core.setOutput('promoted', 'true');
+            core.setOutput('tag_name', target.tag_name);
+            core.setOutput('html_url', target.html_url);
+            core.setOutput('repo_name', `${owner}/${repo}`);
+
+      - name: Notify Telegram for remote promotion
+        if: ${{ steps.promote.outputs.promoted == 'true' && secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RELEASE_TAG: ${{ steps.promote.outputs.tag_name }}
+          RELEASE_URL: ${{ steps.promote.outputs.html_url }}
+          RELEASE_REPO: ${{ steps.promote.outputs.repo_name }}
+        run: |
+          MESSAGE=$(cat <<EOF
+          ✅ Release promoted to stable
+          Repository: ${RELEASE_REPO}
+          Tag: ${RELEASE_TAG}
+          URL: ${RELEASE_URL}
+          EOF
+          )
+
+          curl --fail --silent --show-error \
+            -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,15 +75,15 @@ jobs:
           ZIP_NAME=$(basename "$ZIP_FILE")
           REPO="${{ github.repository }}"
           TAG="${{ github.ref_name }}"
-          
+
           CLEAN_VERSION="${TAG#v}"
           VERSION_CODE=$(echo $CLEAN_VERSION | awk -F. '{printf "%d%02d%02d", $1, $2, $3}')
-          
+
           echo "ZIP_PATH=output/$ZIP_NAME" >> $GITHUB_ENV
-          
+
           DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$ZIP_NAME"
           CHANGELOG_URL="https://raw.githubusercontent.com/$REPO/master/changelog.md"
-          
+
           cat <<EOF > /tmp/update.json
           {
             "version": "$TAG",
@@ -92,7 +92,7 @@ jobs:
             "changelog": "$CHANGELOG_URL"
           }
           EOF
-          
+
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           echo "## $TAG" > /tmp/changelog.md
           echo "" >> /tmp/changelog.md
@@ -108,10 +108,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: false
-          prerelease: false
+          prerelease: true
           files: ${{ env.ZIP_PATH }}
           body_path: /tmp/changelog.md
-          
+
       - name: Create Remote Release (KernelSU-Repo)
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -120,7 +120,7 @@ jobs:
           repository: KernelSU-Modules-Repo/hybrid_mount
           tag_name: ${{ github.ref_name }}
           draft: false
-          prerelease: false
+          prerelease: true
           files: ${{ env.ZIP_PATH }}
           body_path: /tmp/changelog.md
 
@@ -129,15 +129,15 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           git fetch origin master
           git checkout master
-          
+
           mv /tmp/update.json update.json
           cat /tmp/changelog.md | cat - changelog.md > temp && mv temp changelog.md
-          
+
           git add update.json changelog.md Cargo.toml
-          
+
           if ! git diff --staged --quiet; then
             git commit -m "chore(release): sync version ${{ github.ref_name }} [skip ci]"
             git push origin master


### PR DESCRIPTION
### Motivation
- Make newly created releases publish as prereleases and automatically promote them to stable after a configurable grace period to allow testing before finalizing. 
- Support promoting a release in this repository and a remote repository `KernelSU-Modules-Repo/hybrid_mount`, and provide optional Telegram notifications on promotion. 

### Description
- Add a scheduled workflow `.github/workflows/promote_prerelease.yml` that runs daily and contains two jobs `promote-local-release` and `promote-remote-release` which find the newest prerelease older than a 3-day grace period and update it to `prerelease: false` via the GitHub REST API using `actions/github-script@v8`.
- The new workflow uses a provided `RELEASE_TOKEN` to promote the remote repo and conditionally sends Telegram notifications when `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets are set by posting a message via the Telegram bot API.
- Update `.github/workflows/release.yml` to publish both the local and remote releases as prereleases by changing `prerelease: false` to `prerelease: true` in the `Create Release (Local)` and `Create Remote Release (KernelSU-Repo)` steps and include minor whitespace cleanups.

### Testing
- No automated tests were added or executed as part of this change.
- Workflow changes will run on GitHub Actions (scheduled or on dispatch) when the repository environment and secrets are present to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd480289c08325a3e00a263ef2dc64)