### PR TITLE
ci: add caches to compilation workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -59,6 +61,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: webui/pnpm-lock.yaml
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -26,6 +26,8 @@ jobs:
           toolchain: nightly
           targets: aarch64-linux-android
           components: rustfmt, clippy
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Format codes
         uses: LoliGothick/rustfmt-check@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -42,6 +44,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: webui/pnpm-lock.yaml
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/update_notify_tool.yml
+++ b/.github/workflows/update_notify_tool.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/notify -> target
+
       - name: Build Notify Tool
         run: |
           cd tools/notify


### PR DESCRIPTION
### Motivation
- Reduce CI build time by caching Rust crate downloads and pnpm dependencies to avoid repeated network fetches and rebuilds.
- Speed up installations like `cargo-ndk` and incremental builds for the `tools/notify` binary by persisting `target` artifacts across runs.

### Description
- Enable broader Rust caching in `build.yml` and `release.yml` by adding `Swatinem/rust-cache@v2` with `cache-all-crates: true`.
- Enable pnpm caching in `build.yml` and `release.yml` via `actions/setup-node@v6` with `cache: 'pnpm'` and `cache-dependency-path: webui/pnpm-lock.yaml` to reuse Web UI dependencies.
- Add a Rust cache step (`Swatinem/rust-cache@v2`) to `lints.yml` to speed up `clippy`/`rustfmt` runs.
- Add a Rust cache step to `update_notify_tool.yml` with `workspaces: tools/notify -> target` to persist `tools/notify` build outputs for faster incremental builds.

### Testing
- Validated that the edited workflow YAML files parse correctly using Ruby YAML loader with `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'`, which reported `OK` for each workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be1d507040832588172c3264a64522)