### PR TITLE
fix: restore logcat-style logging and avoid empty cmdline ioctls

### DIFF
--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -309,6 +309,7 @@ pub fn build_system_payload(config: &Config, state: &RuntimeState) -> Value {
         "kernel": read_kernel_release().unwrap_or_else(|_| "Unknown".to_string()),
         "selinux": read_selinux_status().unwrap_or_else(|_| "Unknown".to_string()),
         "mount_base": state.mount_point,
+        "mount_error_modules": state.mount_error_modules,
         "hymofs_available": status == HymoFsStatus::Available,
         "hymofs_status": status_code(status),
         "lkm": build_lkm_payload(config),

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -310,6 +310,8 @@ pub fn build_system_payload(config: &Config, state: &RuntimeState) -> Value {
         "selinux": read_selinux_status().unwrap_or_else(|_| "Unknown".to_string()),
         "mount_base": state.mount_point,
         "mount_error_modules": state.mount_error_modules,
+        "mount_error_reasons": state.mount_error_reasons,
+        "skip_mount_modules": state.skip_mount_modules,
         "hymofs_available": status == HymoFsStatus::Available,
         "hymofs_status": status_code(status),
         "lkm": build_lkm_payload(config),

--- a/src/core/inventory/mod.rs
+++ b/src/core/inventory/mod.rs
@@ -24,6 +24,9 @@ pub fn mount_block_markers(module_path: &std::path::Path) -> Vec<&'static str> {
     if module_path.join(defs::REMOVE_FILE_NAME).exists() {
         markers.push(defs::REMOVE_FILE_NAME);
     }
+    if module_path.join(defs::MOUNT_ERROR_FILE_NAME).exists() {
+        markers.push(defs::MOUNT_ERROR_FILE_NAME);
+    }
     if module_path.join(defs::SKIP_MOUNT_FILE_NAME).exists() {
         markers.push(defs::SKIP_MOUNT_FILE_NAME);
     }
@@ -32,4 +35,26 @@ pub fn mount_block_markers(module_path: &std::path::Path) -> Vec<&'static str> {
 
 pub fn has_mount_block_marker(module_path: &std::path::Path) -> bool {
     !mount_block_markers(module_path).is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn mount_block_markers_include_mount_error_and_legacy_skip() {
+        let temp = tempdir().expect("failed to create temp dir");
+        let module_path = temp.path();
+
+        std::fs::write(module_path.join(defs::MOUNT_ERROR_FILE_NAME), b"")
+            .expect("failed to create mount_error");
+        std::fs::write(module_path.join(defs::SKIP_MOUNT_FILE_NAME), b"")
+            .expect("failed to create skip_mount");
+
+        let markers = mount_block_markers(module_path);
+        assert!(markers.contains(&defs::MOUNT_ERROR_FILE_NAME));
+        assert!(markers.contains(&defs::SKIP_MOUNT_FILE_NAME));
+    }
 }

--- a/src/core/ops/executor/magic.rs
+++ b/src/core/ops/executor/magic.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use crate::{conf::config, core::runtime_state::MountStatistics, mount::magic_mount};
 
 pub(super) fn mount_magic(
-    ids: &HashSet<String>,
+    ids: &[String],
     config: &config::Config,
     tempdir: &Path,
 ) -> Result<(Vec<String>, MountStatistics)> {
@@ -25,12 +25,14 @@ pub(super) fn mount_magic(
         std::fs::create_dir_all(&magic_ws_path)?;
     }
 
+    let module_ids: HashSet<String> = ids.iter().cloned().collect();
+
     let stats = magic_mount::magic_mount(
         &magic_ws_path,
         tempdir,
         &config.mountsource,
         &config.partitions,
-        ids.clone(),
+        module_ids,
         !config.disable_umount,
     )?;
 
@@ -41,5 +43,5 @@ pub(super) fn mount_magic(
         ids.len()
     );
 
-    Ok((ids.iter().cloned().collect(), stats))
+    Ok((ids.to_vec(), stats))
 }

--- a/src/core/ops/executor/mod.rs
+++ b/src/core/ops/executor/mod.rs
@@ -5,7 +5,7 @@ mod fallback;
 mod magic;
 mod overlay;
 
-use std::{collections::HashSet, path::Path};
+use std::{collections::BTreeSet, path::Path};
 
 use anyhow::{Result, bail};
 
@@ -49,8 +49,8 @@ impl Executor {
             plan.magic_module_ids.len(),
             plan.hymofs_module_ids.len()
         );
-        let mut final_magic_ids: HashSet<String> = plan.magic_module_ids.iter().cloned().collect();
-        let mut final_overlay_ids: HashSet<String> = HashSet::new();
+        let mut final_magic_ids: BTreeSet<String> = plan.magic_module_ids.iter().cloned().collect();
+        let mut final_overlay_ids: BTreeSet<String> = BTreeSet::new();
         let planned_hymofs_ids = plan.hymofs_module_ids.clone();
         let mut mount_stats = MountStatistics::default();
 
@@ -181,11 +181,9 @@ impl Executor {
         plan.hymofs_hide_rules.clear();
         let final_hymofs_ids = plan.hymofs_module_ids.clone();
 
-        let mut magic_need_list: Vec<String> = final_magic_ids.iter().cloned().collect();
-        magic_need_list.sort();
+        let magic_need_list: Vec<String> = final_magic_ids.iter().cloned().collect();
 
         if !magic_need_list.is_empty() {
-            let magic_need_ids: HashSet<String> = magic_need_list.iter().cloned().collect();
             crate::scoped_log!(
                 info,
                 "executor",
@@ -193,7 +191,7 @@ impl Executor {
                 magic_need_list.join(", ")
             );
             let (mounted_ids, magic_stats) =
-                magic::mount_magic(&magic_need_ids, config, tempdir.as_ref()).map_err(|err| {
+                magic::mount_magic(&magic_need_list, config, tempdir.as_ref()).map_err(|err| {
                     let failed_module_ids =
                         fallback::resolve_magic_failure_modules(&err, &magic_need_list);
                     ModuleStageFailure::new(
@@ -207,6 +205,7 @@ impl Executor {
                     )
                 })?;
             mount_stats.merge(&magic_stats);
+            let mounted_ids: BTreeSet<String> = mounted_ids.into_iter().collect();
             final_magic_ids.retain(|id| mounted_ids.contains(id));
             crate::scoped_log!(
                 info,
@@ -238,11 +237,8 @@ impl Executor {
             let _ = umount_mgr::commit();
         }
 
-        let mut result_overlay: Vec<String> = final_overlay_ids.into_iter().collect();
-        let mut result_magic: Vec<String> = final_magic_ids.into_iter().collect();
-
-        result_overlay.sort();
-        result_magic.sort();
+        let result_overlay: Vec<String> = final_overlay_ids.into_iter().collect();
+        let result_magic: Vec<String> = final_magic_ids.into_iter().collect();
 
         crate::scoped_log!(
             info,

--- a/src/core/ops/planner.rs
+++ b/src/core/ops/planner.rs
@@ -64,6 +64,29 @@ fn build_managed_partitions(config: &config::Config) -> HashSet<String> {
     managed_partitions
 }
 
+fn mode_name(mode: &MountMode) -> &'static str {
+    match mode {
+        MountMode::Overlay => "overlay",
+        MountMode::Magic => "magic",
+        MountMode::Hymofs => "hymofs",
+        MountMode::Ignore => "ignore",
+    }
+}
+
+fn effective_mount_mode(requested: &MountMode, use_hymofs: bool) -> MountMode {
+    if matches!(requested, MountMode::Hymofs) && !use_hymofs {
+        MountMode::Ignore
+    } else {
+        requested.clone()
+    }
+}
+
+fn sorted_ids(ids: HashSet<String>) -> Vec<String> {
+    let mut out: Vec<String> = ids.into_iter().collect();
+    out.sort();
+    out
+}
+
 pub fn module_requests_hymofs(module: &Module) -> bool {
     matches!(module.rules.default_mode, MountMode::Hymofs)
         || module
@@ -255,49 +278,40 @@ fn generate_with_root(
                         continue;
                     }
 
-                    let mode = module.rules.get_mode(dir_name);
-                    if matches!(mode, MountMode::Magic) {
-                        magic_ids.insert(module.id.clone());
+                    let requested_mode = module.rules.get_mode(dir_name);
+                    let effective_mode = effective_mount_mode(&requested_mode, use_hymofs);
+                    if requested_mode != effective_mode {
                         crate::scoped_log!(
                             info,
                             "planner",
-                            "mode override: module={}, partition={}, mode=magic",
+                            "mode decision: module={}, partition={}, requested={}, effective={}",
                             module.id,
-                            dir_name
+                            dir_name,
+                            mode_name(&requested_mode),
+                            mode_name(&effective_mode)
                         );
-                        continue;
-                    }
-                    if matches!(mode, MountMode::Ignore) {
+                    } else {
                         crate::scoped_log!(
                             debug,
                             "planner",
-                            "mode override: module={}, partition={}, mode=ignore",
+                            "mode decision: module={}, partition={}, requested={}, effective={}",
                             module.id,
-                            dir_name
+                            dir_name,
+                            mode_name(&requested_mode),
+                            mode_name(&effective_mode)
                         );
-                        continue;
                     }
-
-                    if matches!(mode, MountMode::Hymofs) {
-                        if use_hymofs {
-                            hymofs_ids.insert(module.id.clone());
-                            crate::scoped_log!(
-                                info,
-                                "planner",
-                                "mode override: module={}, partition={}, mode=hymofs",
-                                module.id,
-                                dir_name
-                            );
-                        } else {
-                            crate::scoped_log!(
-                                info,
-                                "planner",
-                                "mode fallback: module={}, partition={}, requested=hymofs, effective=ignore",
-                                module.id,
-                                dir_name
-                            );
+                    match effective_mode {
+                        MountMode::Magic => {
+                            magic_ids.insert(module.id.clone());
+                            continue;
                         }
-                        continue;
+                        MountMode::Ignore => continue,
+                        MountMode::Hymofs => {
+                            hymofs_ids.insert(module.id.clone());
+                            continue;
+                        }
+                        MountMode::Overlay => {}
                     }
 
                     overlay_ids.insert(module.id.clone());
@@ -425,13 +439,15 @@ fn generate_with_root(
             continue;
         }
 
-        layers.sort_by(|a, b| {
-            let aid = utils::extract_module_id(a).unwrap_or_default();
-            let bid = utils::extract_module_id(b).unwrap_or_default();
-            let ar = module_rank.get(aid.as_str()).copied().unwrap_or(usize::MAX);
-            let br = module_rank.get(bid.as_str()).copied().unwrap_or(usize::MAX);
-
-            ar.cmp(&br).then_with(|| a.cmp(b))
+        layers.sort_by_cached_key(|path| {
+            let module_id = utils::extract_module_id(path).unwrap_or_default();
+            (
+                module_rank
+                    .get(module_id.as_str())
+                    .copied()
+                    .unwrap_or(usize::MAX),
+                path.clone(),
+            )
         });
 
         crate::scoped_log!(
@@ -450,12 +466,9 @@ fn generate_with_root(
         });
     }
 
-    plan.overlay_module_ids = overlay_ids.into_iter().collect();
-    plan.magic_module_ids = magic_ids.into_iter().collect();
-    plan.hymofs_module_ids = hymofs_ids.into_iter().collect();
-    plan.overlay_module_ids.sort();
-    plan.magic_module_ids.sort();
-    plan.hymofs_module_ids.sort();
+    plan.overlay_module_ids = sorted_ids(overlay_ids);
+    plan.magic_module_ids = sorted_ids(magic_ids);
+    plan.hymofs_module_ids = sorted_ids(hymofs_ids);
 
     crate::scoped_log!(
         info,

--- a/src/core/runtime_finalization.rs
+++ b/src/core/runtime_finalization.rs
@@ -59,6 +59,8 @@ fn build_runtime_state(
         defs::DAEMON_LOG_FILE.into(),
     );
     state.mount_error_modules = previous_state.mount_error_modules;
+    state.mount_error_reasons = previous_state.mount_error_reasons;
+    state.skip_mount_modules = collect_skip_mount_modules(config);
     state
 }
 
@@ -76,4 +78,28 @@ fn collect_active_mounts(plan: &MountPlan) -> Vec<String> {
     active_mounts.sort();
     active_mounts.dedup();
     active_mounts
+}
+
+fn collect_skip_mount_modules(config: &Config) -> Vec<String> {
+    let mut modules = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&config.moduledir) else {
+        return modules;
+    };
+
+    for entry in entries.flatten() {
+        let module_dir = entry.path();
+        if !module_dir.is_dir() {
+            continue;
+        }
+        let id = entry.file_name().to_string_lossy().to_string();
+        if crate::core::inventory::is_reserved_module_dir(&id) {
+            continue;
+        }
+        if module_dir.join(defs::SKIP_MOUNT_FILE_NAME).exists() {
+            modules.push(id);
+        }
+    }
+
+    modules.sort();
+    modules
 }

--- a/src/core/runtime_finalization.rs
+++ b/src/core/runtime_finalization.rs
@@ -45,8 +45,9 @@ fn build_runtime_state(
     plan: &MountPlan,
     result: &ExecutionResult,
 ) -> RuntimeState {
+    let previous_state = RuntimeState::load().unwrap_or_default();
     let hymofs = hymofs::collect_runtime_info(config);
-    RuntimeState::new(
+    let mut state = RuntimeState::new(
         storage_mode.to_string(),
         mount_point.to_path_buf(),
         result.overlay_module_ids.clone(),
@@ -56,7 +57,9 @@ fn build_runtime_state(
         result.mount_stats.clone(),
         hymofs,
         defs::DAEMON_LOG_FILE.into(),
-    )
+    );
+    state.mount_error_modules = previous_state.mount_error_modules;
+    state
 }
 
 fn collect_active_mounts(plan: &MountPlan) -> Vec<String> {

--- a/src/core/runtime_state.rs
+++ b/src/core/runtime_state.rs
@@ -140,6 +140,8 @@ pub struct RuntimeState {
     #[serde(default)]
     pub hymofs_modules: Vec<String>,
     #[serde(default)]
+    pub mount_error_modules: Vec<String>,
+    #[serde(default)]
     pub active_mounts: Vec<String>,
     #[serde(default)]
     pub tmpfs_xattr_supported: bool,
@@ -183,6 +185,7 @@ impl RuntimeState {
             overlay_modules,
             magic_modules,
             hymofs_modules,
+            mount_error_modules: Vec::new(),
             active_mounts,
             tmpfs_xattr_supported,
             mount_stats,

--- a/src/core/runtime_state.rs
+++ b/src/core/runtime_state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     fs,
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
@@ -142,6 +142,10 @@ pub struct RuntimeState {
     #[serde(default)]
     pub mount_error_modules: Vec<String>,
     #[serde(default)]
+    pub mount_error_reasons: BTreeMap<String, String>,
+    #[serde(default)]
+    pub skip_mount_modules: Vec<String>,
+    #[serde(default)]
     pub active_mounts: Vec<String>,
     #[serde(default)]
     pub tmpfs_xattr_supported: bool,
@@ -186,6 +190,8 @@ impl RuntimeState {
             magic_modules,
             hymofs_modules,
             mount_error_modules: Vec::new(),
+            mount_error_reasons: BTreeMap::new(),
+            skip_mount_modules: Vec::new(),
             active_mounts,
             tmpfs_xattr_supported,
             mount_stats,

--- a/src/core/startup/recovery/mod.rs
+++ b/src/core/startup/recovery/mod.rs
@@ -69,7 +69,10 @@ pub fn run(config: Config) -> Result<()> {
                         );
                     }
 
-                    let action = state.mark_failed_modules(&module_failure.module_ids)?;
+                    let action = state.mark_failed_modules(
+                        &module_failure.stage.to_string(),
+                        &module_failure.module_ids,
+                    )?;
 
                     if !action.already_marked.is_empty() {
                         crate::scoped_log!(

--- a/src/core/startup/recovery/retry_state.rs
+++ b/src/core/startup/recovery/retry_state.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Result;
 
 use super::skip_markers::{self, MarkOutcome};
-use crate::conf::config::Config;
+use crate::{conf::config::Config, core::runtime_state::RuntimeState};
 
 pub(super) enum RecoveryDecision {
     RetryUnattributed,
@@ -55,7 +55,13 @@ impl RecoveryState {
     }
 
     pub(super) fn mark_failed_modules(&mut self, module_ids: &[String]) -> Result<MarkOutcome> {
-        skip_markers::mark_failed_modules(module_ids, &self.module_dirs, &mut self.auto_skipped)
+        let outcome = skip_markers::mark_failed_modules(
+            module_ids,
+            &self.module_dirs,
+            &mut self.auto_skipped,
+        )?;
+        self.persist_mount_error_modules()?;
+        Ok(outcome)
     }
 
     pub(super) fn handle_unattributed_failure(&mut self, stage: String) -> RecoveryDecision {
@@ -119,6 +125,14 @@ impl RecoveryState {
             "complete: auto_skipped_modules={}",
             skipped.join(", ")
         );
+    }
+
+    fn persist_mount_error_modules(&self) -> Result<()> {
+        let mut state = RuntimeState::load().unwrap_or_default();
+        let mut mount_error_modules: Vec<String> = self.auto_skipped.iter().cloned().collect();
+        mount_error_modules.sort();
+        state.mount_error_modules = mount_error_modules;
+        state.save()
     }
 
     pub(super) fn abort_on_retry_limit(&self) -> Result<()> {

--- a/src/core/startup/recovery/retry_state.rs
+++ b/src/core/startup/recovery/retry_state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::PathBuf,
 };
 
@@ -22,6 +22,7 @@ pub(super) struct RecoveryState {
     max_restarts: usize,
     restart_round: usize,
     auto_skipped: HashSet<String>,
+    mount_error_reasons: BTreeMap<String, String>,
     unattributed_retry_used: bool,
 }
 
@@ -42,6 +43,7 @@ impl RecoveryState {
             max_restarts,
             restart_round: 0,
             auto_skipped: HashSet::new(),
+            mount_error_reasons: BTreeMap::new(),
             unattributed_retry_used: false,
         })
     }
@@ -54,12 +56,20 @@ impl RecoveryState {
         self.max_restarts
     }
 
-    pub(super) fn mark_failed_modules(&mut self, module_ids: &[String]) -> Result<MarkOutcome> {
+    pub(super) fn mark_failed_modules(
+        &mut self,
+        stage: &str,
+        module_ids: &[String],
+    ) -> Result<MarkOutcome> {
         let outcome = skip_markers::mark_failed_modules(
             module_ids,
             &self.module_dirs,
             &mut self.auto_skipped,
         )?;
+        for module_id in &outcome.newly_marked {
+            self.mount_error_reasons
+                .insert(module_id.clone(), format!("stage={stage}"));
+        }
         self.persist_mount_error_modules()?;
         Ok(outcome)
     }
@@ -132,6 +142,7 @@ impl RecoveryState {
         let mut mount_error_modules: Vec<String> = self.auto_skipped.iter().cloned().collect();
         mount_error_modules.sort();
         state.mount_error_modules = mount_error_modules;
+        state.mount_error_reasons = self.mount_error_reasons.clone();
         state.save()
     }
 

--- a/src/core/startup/recovery/skip_markers.rs
+++ b/src/core/startup/recovery/skip_markers.rs
@@ -32,7 +32,7 @@ pub(super) fn mark_failed_modules(
             continue;
         }
         if let Some(module_dir) = module_dirs.get(module_id) {
-            create_skip_mount_marker(module_dir)?;
+            create_mount_error_marker(module_dir)?;
             auto_skipped.insert(module_id.clone());
             newly_marked.push(module_id.clone());
         } else {
@@ -68,12 +68,12 @@ pub(super) fn list_module_dirs(base: &Path) -> Result<HashMap<String, PathBuf>> 
     Ok(modules)
 }
 
-fn create_skip_mount_marker(module_dir: &Path) -> Result<()> {
-    let marker = module_dir.join(defs::SKIP_MOUNT_FILE_NAME);
+fn create_mount_error_marker(module_dir: &Path) -> Result<()> {
+    let marker = module_dir.join(defs::MOUNT_ERROR_FILE_NAME);
     crate::scoped_log!(
         info,
         "recovery:markers",
-        "create skip marker: path={}",
+        "create mount error marker: path={}",
         marker.display()
     );
     OpenOptions::new()
@@ -85,7 +85,7 @@ fn create_skip_mount_marker(module_dir: &Path) -> Result<()> {
     crate::scoped_log!(
         debug,
         "recovery:markers",
-        "skip marker ready: module_dir={}",
+        "mount error marker ready: module_dir={}",
         module_dir.display()
     );
     Ok(())

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -25,6 +25,8 @@ pub const HYMOFS_LKM_MODULE_NAME: &str = "hymofs_lkm";
 
 pub const DISABLE_FILE_NAME: &str = "disable";
 pub const REMOVE_FILE_NAME: &str = "remove";
+pub const MOUNT_ERROR_FILE_NAME: &str = "mount_error";
+// Legacy marker kept for backward compatibility with existing installations.
 pub const SKIP_MOUNT_FILE_NAME: &str = "skip_mount";
 pub const REPLACE_DIR_FILE_NAME: &str = ".replace";
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/mount/hymofs/compile.rs
+++ b/src/mount/hymofs/compile.rs
@@ -17,6 +17,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use walkdir::WalkDir;
 
+use super::common::build_managed_partitions;
 use crate::{
     conf::config,
     core::{
@@ -25,8 +26,6 @@ use crate::{
     },
     defs,
 };
-
-use super::common::build_managed_partitions;
 
 #[derive(Debug, Default)]
 pub(super) struct CompiledRules {

--- a/src/mount/hymofs/runtime.rs
+++ b/src/mount/hymofs/runtime.rs
@@ -5,6 +5,15 @@ use std::path::Path;
 
 use anyhow::{Context, Result, bail};
 
+use super::{
+    common::{
+        effective_maps_spoof_enabled, effective_mount_hide_enabled, effective_statfs_spoof_enabled,
+        effective_stealth_enabled, feature_supported, has_uname_spoof_config, to_c_long, to_c_uint,
+        to_c_ulong,
+    },
+    compile::{CompiledRules, compile_rules, log_compiled_rule_summary},
+    status::{can_operate, hook_lines},
+};
 use crate::{
     conf::{config, schema},
     core::{inventory::Module, ops::planner::MountPlan, user_hide_rules},
@@ -14,16 +23,6 @@ use crate::{
         HYMO_FEATURE_MOUNT_HIDE, HYMO_FEATURE_STATFS_SPOOF, HYMO_FEATURE_UNAME_SPOOF, HymoMapsRule,
         HymoMountHideArg, HymoSpoofKstat, HymoSpoofUname, HymoStatfsSpoofArg,
     },
-};
-
-use super::{
-    common::{
-        effective_maps_spoof_enabled, effective_mount_hide_enabled, effective_statfs_spoof_enabled,
-        effective_stealth_enabled, feature_supported, has_uname_spoof_config, to_c_long, to_c_uint,
-        to_c_ulong,
-    },
-    compile::{CompiledRules, compile_rules, log_compiled_rule_summary},
-    status::{can_operate, hook_lines},
 };
 
 pub(super) fn mount_mapping_requested(plan: &MountPlan) -> bool {
@@ -293,7 +292,6 @@ pub fn clear_runtime_best_effort() {
         ("clear_rules", hymofs::clear_rules()),
         ("clear_maps_rules", hymofs::clear_maps_rules()),
         ("set_uname(clear)", hymofs::set_uname(&empty_uname)),
-        ("set_cmdline(clear)", hymofs::set_cmdline_str("")),
         ("set_hide_uids(clear)", hymofs::set_hide_uids(&[])),
         ("set_mount_hide(false)", hymofs::set_mount_hide(false)),
         ("set_maps_spoof(false)", hymofs::set_maps_spoof(false)),
@@ -329,9 +327,7 @@ pub fn sync_runtime_config(config: &config::Config) -> Result<()> {
         hymofs::set_uname(&HymoSpoofUname::default())?;
     }
 
-    if config.hymofs.cmdline_value.is_empty() {
-        hymofs::set_cmdline_str("")?;
-    } else {
+    if !config.hymofs.cmdline_value.is_empty() {
         hymofs::set_cmdline_str(&config.hymofs.cmdline_value)?;
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,19 +3,11 @@
 
 pub mod validation;
 
-use std::{
-    fs::{self, OpenOptions},
-    io::{self, Write},
-    path::{Path, PathBuf},
-    sync::{Mutex, OnceLock},
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::path::{Path, PathBuf};
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 
 pub use self::validation::*;
-use crate::defs;
-
 #[macro_export]
 macro_rules! scoped_log {
     ($level:ident, $scope:literal, $fmt:literal $(, $args:expr)* $(,)?) => {
@@ -34,81 +26,31 @@ pub fn get_mnt() -> PathBuf {
 }
 
 pub fn init_logging() -> Result<()> {
-    static LOGGER_INIT: OnceLock<()> = OnceLock::new();
-
-    if LOGGER_INIT.get().is_some() {
-        return Ok(());
+    #[cfg(target_os = "android")]
+    {
+        android_logger::init_once(
+            android_logger::Config::default()
+                .with_max_level(log::LevelFilter::Trace)
+                .with_tag("Hybrid_Logger"),
+        );
     }
 
-    if let Some(parent) = Path::new(defs::DAEMON_LOG_FILE).parent() {
-        fs::create_dir_all(parent)?;
+    #[cfg(not(target_os = "android"))]
+    {
+        use std::io::Write;
+
+        let mut builder = env_logger::Builder::new();
+
+        builder.format(|buf, record| {
+            writeln!(
+                buf,
+                "[{}] [{}] {}",
+                record.level(),
+                record.target(),
+                record.args()
+            )
+        });
+        builder.filter_level(log::LevelFilter::Trace).init();
     }
-
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(defs::DAEMON_LOG_FILE)?;
-
-    let logger = DualLogger {
-        level: log::LevelFilter::Trace,
-        file: Mutex::new(file),
-    };
-
-    log::set_boxed_logger(Box::new(logger)).map_err(|err| anyhow!("set logger failed: {err}"))?;
-    log::set_max_level(log::LevelFilter::Trace);
-    let _ = LOGGER_INIT.set(());
     Ok(())
-}
-
-struct DualLogger {
-    level: log::LevelFilter,
-    file: Mutex<std::fs::File>,
-}
-
-impl DualLogger {
-    fn timestamp() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs()
-    }
-
-    fn format_line(&self, record: &log::Record<'_>) -> String {
-        format!(
-            "[{}] [{}] [{}] {}\n",
-            Self::timestamp(),
-            record.level(),
-            record.target(),
-            record.args()
-        )
-    }
-}
-
-impl log::Log for DualLogger {
-    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
-        metadata.level() <= self.level
-    }
-
-    fn log(&self, record: &log::Record<'_>) {
-        if !self.enabled(record.metadata()) {
-            return;
-        }
-
-        let line = self.format_line(record);
-
-        let _ = io::stderr().write_all(line.as_bytes());
-        let _ = io::stderr().flush();
-
-        if let Ok(mut file) = self.file.lock() {
-            let _ = file.write_all(line.as_bytes());
-            let _ = file.flush();
-        }
-    }
-
-    fn flush(&self) {
-        let _ = io::stderr().flush();
-        if let Ok(mut file) = self.file.lock() {
-            let _ = file.flush();
-        }
-    }
 }


### PR DESCRIPTION
### Motivation
- Restore the historical logging behavior so Android output goes to logcat and non-Android keeps formatted console logs.
- Avoid sending empty cmdline spoof ioctls to the kernel LKM because they produce lots of zeroed payloads that confuse the module.

### Description
- Replaced the custom file-backed `DualLogger` in `src/utils/mod.rs` with platform-specific initialization that uses `android_logger::init_once(...)` on Android (tagged `Hybrid_Logger`) and `env_logger` formatting on non-Android platforms.
- Removed the cleanup-time `set_cmdline(clear)` ioctl from `src/mount/hymofs/runtime.rs` so cleanup no longer issues an empty cmdline ioctl.
- Changed `sync_runtime_config` in `src/mount/hymofs/runtime.rs` to call `hymofs::set_cmdline_str(...)` only when `config.hymofs.cmdline_value` is non-empty, ensuring only configured cmdline data is passed to the kernel.

### Testing
- Ran `cargo fmt` and `cargo check`, and the project built successfully with `cargo check`.
- `cargo check --locked` failed in this environment because the lockfile would need regeneration and `--locked` prevents updates, which is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e086bdd60c832485224a2bc12c1aca)