### PR TITLE
Panic early when KernelSU late-load mode is detected

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,10 @@ use mimalloc::MiMalloc;
 static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() -> Result<()> {
-    if std::env::var("KSU_LATE_LOAD").is_ok() && std::env::var("KSU").is_ok() {
-        panic!("! unsupported late load mode");
+    if matches!(std::env::var("KSU_LATE_LOAD").as_deref(), Ok("1")) {
+        panic!("不支持Late-load（越狱）模式");
     }
+
     let cli = Cli::parse();
     core::entry::run(cli)
 }


### PR DESCRIPTION
### Motivation
- Ensure the Rust backend fails fast when running under KernelSU late-load (jailbreak) mode so the process exits at the earliest possible stage.

### Description
- Update `src/main.rs` to check `KSU_LATE_LOAD` using the same value semantics as the shell check by testing for `KSU_LATE_LOAD=1` via `matches!(std::env::var("KSU_LATE_LOAD").as_deref(), Ok("1"))`.
- Replace the previous presence-based check with an explicit value check and remove the `KSU` variable dependency.
- Emit a panic with the message `不支持Late-load（越狱）模式` before CLI parsing to abort startup immediately.

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded.
- Ran `cargo check` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e73afd39e483249795989eba9575ba)