### PR TITLE
webui: add Indonesian to language selector

### DIFF
--- a/webui/src/lib/stores/uiStore.ts
+++ b/webui/src/lib/stores/uiStore.ts
@@ -22,6 +22,7 @@ const createUiStore = () => {
     { code: "ru-RU", name: "Русский" },
     { code: "uk-UA", name: "Українська" },
     { code: "vi-VN", name: "Tiếng Việt" },
+    { code: "id-ID", name: "Bahasa Indonesia" },
     { code: "zh-CN", name: "简体中文" },
     { code: "zh-TW", name: "繁體中文" },
   ].sort((a, b) => {


### PR DESCRIPTION
### Motivation
- The WebUI included a locale file `webui/src/locales/id-ID.json` but `id-ID` was not present in the `availableLanguages` list, so Bahasa Indonesia could not be chosen in the language dialog.

### Description
- Inserted `{ code: "id-ID", name: "Bahasa Indonesia" }` into the `availableLanguages` array in `webui/src/lib/stores/uiStore.ts` so the Indonesian locale becomes selectable.

### Testing
- Verified the change and locale presence using `git diff -- webui/src/lib/stores/uiStore.ts` and `nl -ba webui/src/locales/id-ID.json`, then committed the update with `git commit` (commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165edc5b2c8325bac2b9c862af1ab8)