### PR TITLE
fix: correct finit_module syscall number for aarch64 (273 not 379)

### DIFF
--- a/src/sys/lkm.rs
+++ b/src/sys/lkm.rs
@@ -32,10 +32,7 @@ pub struct LkmStatus {
     target_arch = "aarch64"
 ))]
 const SYS_FINIT_MODULE_NUM: libc::c_long = 273;
-#[cfg(all(
-    any(target_os = "linux", target_os = "android"),
-    target_arch = "arm"
-))]
+#[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "arm"))]
 const SYS_FINIT_MODULE_NUM: libc::c_long = 379;
 #[cfg(all(
     any(target_os = "linux", target_os = "android"),

--- a/src/sys/lkm.rs
+++ b/src/sys/lkm.rs
@@ -29,7 +29,12 @@ pub struct LkmStatus {
 
 #[cfg(all(
     any(target_os = "linux", target_os = "android"),
-    any(target_arch = "aarch64", target_arch = "arm")
+    target_arch = "aarch64"
+))]
+const SYS_FINIT_MODULE_NUM: libc::c_long = 273;
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    target_arch = "arm"
 ))]
 const SYS_FINIT_MODULE_NUM: libc::c_long = 379;
 #[cfg(all(


### PR DESCRIPTION
**Bug:** `SYS_FINIT_MODULE_NUM` was hardcoded as `379` for both ARM (32-bit) and aarch64 (64-bit).  

**Effect:** On all aarch64 devices, loading the Kasumi LKM fails with `ENOSYS (Function not implemented)` because syscall 379 doesn't exist on aarch64 — the correct number is `273` per the generic syscall table (`asm-generic/unistd.h`).  

**Fix:** Split the cfg gates — `aarch64` → `273`, `arm` → `379` (unchanged).  

Ref:https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/unistd.h#L663