### PR TITLE
fix: support Kasumi protocol v16 status output

### DIFF
--- a/src/core/api/kasumi.rs
+++ b/src/core/api/kasumi.rs
@@ -76,6 +76,13 @@ pub struct KasumiVersionPayload {
 }
 
 pub fn parse_kasumi_rule_listing(listing: &str) -> Result<Vec<KasumiRuleEntry>> {
+    const STATUS_KEYS: &[&str] = &[
+        "maps_spoof",
+        "mount_hide",
+        "selinux_fix",
+        "statfs_spoof",
+        "stealth",
+    ];
     let mut rules = Vec::new();
 
     for raw_line in listing.lines() {
@@ -147,6 +154,12 @@ pub fn parse_kasumi_rule_listing(listing: &str) -> Result<Vec<KasumiRuleEntry>> 
                     file_type: None,
                 });
             }
+            _ if STATUS_KEYS.contains(&kind_raw)
+                && matches!(parts.next(), Some("enabled" | "disabled"))
+                && parts.next().is_none() =>
+            {
+                continue;
+            }
             _ => bail!("unknown Kasumi rule type in listing: {line}"),
         }
     }
@@ -213,5 +226,36 @@ fn mismatch_message(status: KasumiStatus, kernel_version: i32) -> Option<String>
         )),
         KasumiStatus::Available => None,
         KasumiStatus::NotPresent => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_kasumi_rule_listing;
+
+    #[test]
+    fn rule_listing_skips_feature_status_lines() {
+        let listing = "Kasumi Protocol: 16\nstealth enabled\nselinux_fix disabled\nADD /system/app /mirror/app 1\n";
+
+        let rules = parse_kasumi_rule_listing(listing).unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, "ADD");
+    }
+
+    #[test]
+    fn rule_listing_rejects_unknown_non_status_lines() {
+        let result = parse_kasumi_rule_listing("unknown_feature enabled\n");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rule_listing_keeps_lowercase_path_rules_named_like_status_values() {
+        let rules = parse_kasumi_rule_listing("hide enabled\ninject disabled\n").unwrap();
+
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].path.as_deref(), Some("enabled"));
+        assert_eq!(rules[1].path.as_deref(), Some("disabled"));
     }
 }

--- a/src/sys/kasumi.rs
+++ b/src/sys/kasumi.rs
@@ -951,7 +951,22 @@ pub fn set_hide_uids(uids: &[u32]) -> Result<()> {
 }
 
 pub fn fix_mounts() -> Result<()> {
-    ioctl_noarg("fix_mounts", KSM_IOC_REORDER_MNT_ID)
+    match ioctl_noarg("fix_mounts", KSM_IOC_REORDER_MNT_ID) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if error.downcast_ref::<Errno>().is_some_and(|errno| {
+                matches!(errno.raw_os_error(), libc::EOPNOTSUPP | libc::ENOTTY)
+            }) =>
+        {
+            crate::scoped_log!(
+                debug,
+                "kasumi:fix_mounts",
+                "skip: reason=unsupported_by_kernel_module"
+            );
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
 }
 
 pub fn hide_overlay_xattrs(path: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary

- treat unsupported legacy `fix_mounts` as an optional Kasumi operation
- skip known protocol v16 feature-status records in rule listings
- keep unknown records and valid lowercase path rules strict

## Root cause

Kasumi protocol v16 returns `EOPNOTSUPP` for the legacy `KSM_IOC_REORDER_MNT_ID` ioctl and appends records such as `stealth enabled` and `selinux_fix enabled` to rule listings. Runtime configuration was applied successfully, but userspace reported failure during `fix_mounts` or status refresh.

## Validation

- Android arm64 full release build
- Android arm64 Clippy for all targets with `-D warnings`
- Android arm64 test targets compiled with `cargo ndk ... test --no-run`
- Pixel 9 Pro: runtime config apply returns `applied: true`, rule listing succeeds, Kasumi remains `available`