### PR TITLE
fix: prevent non-GKI KMI status failures from blocking daemon startup

### DIFF
--- a/src/core/daemon/server.rs
+++ b/src/core/daemon/server.rs
@@ -53,7 +53,14 @@ pub fn serve() -> Result<()> {
             );
             RuntimeState::default()
         }
-        Err(err) => return Err(err).context("Failed to load daemon runtime state"),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "Failed to load daemon runtime state: path={}",
+                    defs::STATE_FILE
+                )
+            });
+        }
     };
     let listener = UnixListener::bind(defs::SOCKET_FILE)
         .with_context(|| format!("Failed to bind daemon socket {}", defs::SOCKET_FILE))?;

--- a/src/core/daemon/server.rs
+++ b/src/core/daemon/server.rs
@@ -42,7 +42,19 @@ pub fn serve() -> Result<()> {
     fs::create_dir_all(defs::RUN_DIR)
         .with_context(|| format!("Failed to create daemon run directory {}", defs::RUN_DIR))?;
     cleanup_stale_runtime_files()?;
-    let mut runtime_state = RuntimeState::load()?;
+    let mut runtime_state = match RuntimeState::load() {
+        Ok(state) => state,
+        Err(err) if error_is_not_found(&err) => {
+            crate::scoped_log!(
+                warn,
+                "daemon",
+                "runtime state missing, starting with defaults: path={}",
+                defs::STATE_FILE
+            );
+            RuntimeState::default()
+        }
+        Err(err) => return Err(err).context("Failed to load daemon runtime state"),
+    };
     let listener = UnixListener::bind(defs::SOCKET_FILE)
         .with_context(|| format!("Failed to bind daemon socket {}", defs::SOCKET_FILE))?;
     fs::set_permissions(defs::SOCKET_FILE, fs::Permissions::from_mode(0o600))
@@ -278,6 +290,13 @@ fn cleanup_stale_runtime_files() -> Result<()> {
     Ok(())
 }
 
+fn error_is_not_found(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<IoError>())
+        .any(|error| error.kind() == ErrorKind::NotFound)
+}
+
 fn cleanup_stale_socket(path: &Path) -> Result<()> {
     if !path.exists() {
         return Ok(());
@@ -416,6 +435,20 @@ impl Drop for DaemonRuntimeGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_runtime_state_error_is_recoverable() {
+        let error = anyhow::Error::from(IoError::from(ErrorKind::NotFound));
+
+        assert!(error_is_not_found(&error));
+    }
+
+    #[test]
+    fn malformed_runtime_state_error_is_not_recoverable() {
+        let error = anyhow::anyhow!("invalid runtime state");
+
+        assert!(!error_is_not_found(&error));
+    }
 
     #[test]
     fn limited_daemon_request_reader_accepts_one_line() {

--- a/src/mount/kasumi/status.rs
+++ b/src/mount/kasumi/status.rs
@@ -68,7 +68,7 @@ fn runtime_probe() -> Result<RuntimeProbe> {
         Ok(kmi) => kmi,
         Err(err) => {
             crate::scoped_log!(
-                warn,
+                debug,
                 "kasumi:status",
                 "KMI unavailable for runtime status: error={:#}",
                 err

--- a/src/mount/kasumi/status.rs
+++ b/src/mount/kasumi/status.rs
@@ -64,6 +64,19 @@ fn runtime_probe() -> Result<RuntimeProbe> {
         (None, Vec::new(), 0)
     };
 
+    let current_kmi = match lkm::current_kmi() {
+        Ok(kmi) => kmi,
+        Err(err) => {
+            crate::scoped_log!(
+                warn,
+                "kasumi:status",
+                "KMI unavailable for runtime status: error={:#}",
+                err
+            );
+            String::new()
+        }
+    };
+
     let probe = RuntimeProbe {
         checked_at: Instant::now(),
         live_status,
@@ -73,7 +86,7 @@ fn runtime_probe() -> Result<RuntimeProbe> {
         hooks,
         rule_count,
         kernel_supported: kasumi::kernel_is_supported()?,
-        current_kmi: lkm::current_kmi()?,
+        current_kmi,
     };
     *cache
         .lock()

--- a/src/sys/lkm.rs
+++ b/src/sys/lkm.rs
@@ -285,3 +285,23 @@ pub fn autoload_if_needed(config: &KasumiConfig) -> Result<bool> {
     load(config)?;
     Ok(true)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_kmi_from_release;
+
+    #[test]
+    fn parses_gki_release() {
+        assert_eq!(
+            parse_kmi_from_release("5.15.153-android13-8-g123456789abc").unwrap(),
+            "android13-5.15"
+        );
+    }
+
+    #[test]
+    fn rejects_vendor_release_without_android_kmi() {
+        let error = parse_kmi_from_release("5.15.207-g3ddad1147e36").unwrap_err();
+
+        assert!(error.to_string().contains("has no Android version"));
+    }
+}


### PR DESCRIPTION
## Summary

- keep Kasumi runtime status collection working when a vendor kernel release has no -androidNN- KMI segment
- allow the daemon to start with default state only when daemon_state.json is missing
- keep malformed, inaccessible, or otherwise invalid runtime state errors fatal
- add regression coverage for standard GKI and Sony-style vendor kernel releases

## Root cause

On a Sony XQ-DQ72 running kernel 5.15.207-g3ddad1147e36, OverlayFS mounts completed successfully, but runtime finalization still collected Kasumi telemetry while Kasumi was disabled. lkm::current_kmi() rejected the vendor release because it has no -androidNN- segment, causing the metamodule mount script to exit with status 1 before daemon_state.json was written.

The WebUI then attempted to wake the daemon. The daemon treated the missing runtime state file as fatal and exited before binding /data/adb/hybrid-mount/run/daemon.sock, so the user only saw the secondary 3-second socket timeout.

## Behavior

current_kmi() remains strict for actual LKM selection and loading. Only the optional runtime status field falls back to an empty KMI with a warning, so non-GKI kernels are not mapped to an arbitrary prebuilt module.

Daemon recovery is limited to NotFound. Corrupt JSON, permission failures, and other state errors still fail with context.

Full non-GKI manual KMI selection through the LKM status/WebUI flow is intentionally out of scope for this PR.

## Validation

- cargo fmt --all -- --check
- Android arm64 cargo check --target aarch64-linux-android --all-features --tests
- Android arm64 cargo clippy --target aarch64-linux-android --all-features --tests -- -D warnings
- Android arm64 control-plane-only check
- Android arm64 no-default-features check